### PR TITLE
Edit fusionspec

### DIFF
--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -45,7 +45,7 @@ function appendOrders( bytes32 [] orders){
 	for(i=0; i<orders.length; i++){
 		if("check signature of order") {
 			// hash order without signature
-			orderHashSha = Kecca256(orderHashSha, order[i]) 
+			orderHashSha = Kecca256(orderHashSha, orders[i]) 
 		}
 	}
 }

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -308,11 +308,11 @@ In the snark-applyAuction the snark circuits are dominated by the following oper
 
 - Iteration over all orders -> constraints multiply #orders
 - For each order we open 3 leaves: 
-	accountLeaf, balanceLeaf_SendingToken, balanceLeaf_ReceivingToken -> 3 * log_2(#balances) * 2 * #pedersonHashConstraints
+	- accountLeaf, balanceLeaf\_SendingToken, balanceLeaf\_ReceivingToken -> 3 * log_2(#balances) * 2 * #pedersonHashConstraints
 - for each order we recalculate the merkle root: 
-	accountLeaf, balanceLeaf_SendingToken, balanceLeaf_ReceivingToken -> log_2(#balances) * 2 * #pedersonHashConstraints
+	- accountLeaf, balanceLeaf\_SendingToken, balanceLeaf\_ReceivingToken -> 2* log_2(#balances) * 2 * #pedersonHashConstraints
 
-That means that the number of constraints for #orders will be about #orders * log_2(#balances) * 8 * #pedersonHashConstraints implying that we could process roughly 5K orders with 1M accounts, if there are  2K constraints per pedersonHash.
+Together then, the number of constraints will be of magnitude #orders * log_2(#balances) * 10 * #pedersonHashConstraints implying that we could process roughly 5K orders with 1M accounts, if there are 1.1K constraints per pedersonHash.
 
 
 Biggest foreseen challenge: Generating a trusted setup with 2^28 constraints.

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -39,13 +39,13 @@ The trading workflow consists of the following sequential processes:
 The anchor smart contract on ethereum will offer the following function:
 ```js
 function appendOrders( bytes32 [] orders){ 
-	// some preliminary checks, which will limit the total amount of orders..
+	// some preliminary checks limiting the number of orders..
 
 	// update of orderHashSha
-	for(i=0;i<orders.length;i++){
-		if( "check signature of order"){
+	for(i=0; i<orders.length; i++){
+		if("check signature of order") {
 			// hash order without signature
-			orderHashSha = Kecca256( orderHashSha, order[i]) 
+			orderHashSha = Kecca256(orderHashSha, order[i]) 
 		}
 	}
 }
@@ -107,7 +107,7 @@ After the price submission period, the best solution with the highest trading su
 
 `P` is only the price vector of all prices relative to a reference token `Token_1`. As prices are arbitrage-free, we can calculate the `price Token_i: Token_k` =  `(Token_i:Token_1):(Token_1:Token_k)`
 
-Unfortunately, not all orders below the limit price will be filled completely. It might happen that the account sending the order might not have the balance required to settle the sell order. These orders we are calling uncovered orders and they need to be excluded or only partly be filled. Because of this, the solution submitter needs to provide for each order the fraction of the traded surplus:
+Unfortunately, not all orders below the limit price will be filled completely. It might happen that the account sending the order might not have the balance required to settle the sell order. These orders we are calling uncovered orders and they need to be excluded or only partly be filled. Because of this, the solution submitter must provide the fraction of the traded surplus for each order:
 
 | VV | order_1 | ... | order_K|
 | --- | --- | --- | --- |
@@ -115,7 +115,7 @@ Unfortunately, not all orders below the limit price will be filled completely. I
 
 
 
-These two parts of the solution: VV and P must be provided as data payload to the anchor contract and then the anchor contract will sha-hash them together into `hashBatchInfo`.
+These two parts of the solution: VV and P are provided as data payload to the anchor contract which will sha-hash them together into `hashBatchInfo`.
 
 Now, everyone can check whether the provided solution is actually a valid one. If it is not valid, then anyone can challenge the solution submitter. If this happens, the solution submitter needs to prove that his solution is correct by providing the following snark:
 ```
@@ -126,7 +126,7 @@ Snark - applyAuction(
 	Public: orderHashPederson,
 	Private: priceMatrix PxP,
 	Private: orderVolume
-	Private: [ balanceTRH_I    for 0<I<=N]
+	Private: [balanceTRH_i    for 0<i<=N]
 	Private: orders
 	Private: touched balances + leaf number + balance merkle proofs per order,
 	Private: FollowUpOrderOfAccount [index of later order touching balance])
@@ -136,7 +136,7 @@ The snark would check the following things:
 
 - `priceMatrix` has actually the values as induced by the `hashBatchInfo` (with sha)
 - `orderVolume` VV has actually the values induced by the `hashBatchInfo` (with sha)
-- verify  `[ balanceTRH_I    for 0<I<=N]` hashes to `balanceRH`
+- verify  `[balanceTRH_i    for 0<i<=N]` hashes to `balanceRH`
 - verify  `[VV]` has the values induced by `hashBatchInfo`
 
 - for order in [orders]
@@ -144,11 +144,11 @@ The snark would check the following things:
 	- check that the leaf is owned by sender by opening the accountIndexLeaf
 	- check that the nounce is valid and update it
 	- read the potentially fractional surplus of the order
-	- update the balance by substracting sell volume
+	- update the balance by subtracting sell volume
 	- if `FollowUpOrderOfAccount` == 0
 		- check that balance is positive
 	- else 
-			Check that the other order referenced in `FollowUpOrderOfAccount` has the same receiver and it touches the balance
+		- Check that the other order referenced in `FollowUpOrderOfAccount` has the same receiver and it touches the balance
 	- update the balance by adding buy volume
 	- close balance leaves and update Merkle tree hashes
 	- Keep track of the total `selling surplus` per token


### PR DESCRIPTION
Some other suggestions:

line 11

    In order to align with the notation used in DIZK, we may want to start using T tokens (instead of N which is used for something else).

line 41

    In appendOrders function, shouldn't there be a way of not rehashing all the previous orders? I mention this because of the O(1) algorithm for computing a "Running Mean" in the sense that appending a new value to a dataset where we already know the number of values and the mean of the previous set, one can compute the new mean without recomputing the sum of all previous data entries. 

    ----

    Observe if X_n (the mean of [x_1, x_2, ..., x_n]) and we want to add a new value x_{n+1} then

    X_{n+1} = (\sum_{i=1}^{n+1} x_i)/ (n+1)

    rearranges as

    (n+1)*X_{n+1} = (\sum_{i=1}^n x_i) + x_{n+1} = n*X_n + x_{n+1}

    so that

    X_{n+1} = (n*X_n + x_{n+1})/(n+1)

    i.e. the new mean is expressed in terms of the previous mean, the size of the dataset and the new value to be appended.

    ----

    With this in mind, if we store the current orderHash as an additional field in the contract, then we wouldn't need to loop to append orders.

line 69

    How do we plan to deal with orders in the case of insufficient balance?

line 81

    I would say "Any challenge is, by default, assumed to be legitimate and will be accepted unless the first transition submitter can provide a snark proof of correctness within a predefined time frame (some hours)."

line 293

    >>> k = 10**3
    >>> 21000+k*(6+16+16+64+64+512)*68/8+k*3000+k*60+5000
    8849000

