### PR TITLE
Update dFusionSpec.md

### DIFF
--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -127,7 +127,7 @@ A new batch could immediately start collecting new orders while the previous one
 To process a batch, participants compute the uniform clearing price maximizing the trading surplus between all trading pairs can. 
 The traders surplus of an order is defined as the difference between the uniform clearning price and the limit price, multipied by the volume of the order with respect to some reference token. 
 The exact procedure is described [here]( https://github.com/gnosis/dex-research/blob/master/BatchAuctionOptimization/batchauctions.pdf). 
-Calculating the uniform clearing prices is an np hard optimization problem and most likely the global optimum will not be found in the pre-defined short time frame: `SolvingTime` - we think that 3-10 minutes are reasonable. 
+Calculating the uniform clearing prices is an np-hard optimization problem and most likely the global optimum will not be found in the pre-defined short time frame: `SolvingTime` - estimated between 3-10 minutes. 
 While it is a pity that the global optimum cannot be found, the procedure is still fair, as everyone can submit their best solution.
 Since posting the complete solution (all prices and traded volumes) would be too gas expensive to put on-chain for each candidate solution, participants only submit the 'traders surplus' they claim there solution is able to achieve.
 The anchor contract will store all submissions and will select the solution with the maximal 'traders surplus' as the final solution.

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -63,7 +63,7 @@ In order to avoid double withdraws, we also store a bitmap for each "withdraw me
 Each bit in that maps denotes if the withdraw has alreay been claimed.
 
 Participants can provide state transitions that apply pending deposits and withdrawals only while the order collection process is ongoing (the current batch is not yet frozen).
-Since price finding and order matching is a computationally expensive task, we don't want the account state to change while the optimization problem is ongoing, as this could potentially invalidate correct solutions (e.g. a withdraw could lead to insufficient balance for a matched trade).
+Since price finding and order matching is a computationally expensive task, the account state must not change while the optimization problem is ongoing, as this could potentially invalidate correct solutions (e.g. a withdraw could lead to insufficient balance for a matched trade).
 As soon as the matching of a closed batch is applied, pending withdrawls and deposits can again be applied to the state.
 
 *// TODO state for snark challenge/response, e.g. hashBatchInfo*

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -32,7 +32,7 @@ We therefore "optimistically" accept solutions and set a crypto-economic incenti
 ## State stored in the smart contract
 
 For each account, we chain each of ERC20 token balance together and store them as pedersen hash (not merkleized) in the anchor smart contract.
-This "compressed" representation of all account balances is collision resistant and can thus be used to uniquely commit to the complete "uncompressed" state that lists all balances explicitly. 
+This "compressed" representation of all account balances is collision resistant and can thus be used to uniquely commit to the complete "uncompressed" state containing all balances explicitly. 
 The "uncompressed" state will be stored off-chain. All changes to the state will be announced via smart contract events. 
 Thus, the full state will be fully reproducible for any participant by replaying all blocks since the creation of the smart contract. 
 The following diagram shows how the "compressed" state hash is constructed:

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -45,7 +45,7 @@ Accounts will pay "rent" to occupy an active account. The account index can be u
 Furthermore, we store a bi-map of token address to its index `0 <= t <= T`, for each token that can be traded on the exchange.
 When specifying tokens inside orders, deposits and withdrawel requests, we use the token's index `0 <= t <= T` instead of the full address.
 
-As limit orders and deposits requests are collected they are not directly stored in the smart contract.
+As limit orders and deposits and withdrawal requests are collected they are not directly stored in the smart contract.
 Doing so would require a `SSTORE` evm instruction for each item.
 This would be too gas-expensive:
 Assuming an order can be encoded in 256 bits, storing a batch of 10.000 on chain would cost ~5M gas (5.000 gas for SSTORE * 10.000 orders).

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -74,7 +74,7 @@ To summarize, here is a list of state that is stored inside the smart contract:
 - Bi-Map of ERC20 token addresses to internal dƒusion tokenId that the exchange supports
 - Rolling hash of pending orders, withdrawls and deposit requests (SHA)
 - Map of stateTransitionId to pair of "valid withdrawel requests merkle-root" (SHA) and bitmap of already claimed withdraws
-- Current state of the batch auction (e.g. *price-findeing* vs. *order-collection*)
+- Current state of the batch auction (e.g. *price-finding* vs. *order-collection*)
 
 ## Batch Auction Workflow
 

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -56,7 +56,7 @@ Any participants can apply pending deposit and withdrawal requests to the curren
 To do so, they provide a new state commitment that represents all account balances after the application of pending requests.
 Moreover, as the new state is stored on the smart contract, pending requests are reset.
 
-When a party applies withdrawl requests to the account balance state, they also provide the list of valid withdraws (in form of their merkle root) which we store in the smart contract inside a mapping (`transitionId` -> `valid withdraw merkle root`).
+When a party applies withdrawal requests to the account balance state, they also provide the list of valid withdraws (in form of their Merkle root) which we store in the smart contract inside a mapping (`transitionId` -> `valid withdraw Merkle root`).
 Participants can later claim their withdraw by providing a merkle inclusion proof of their withdraw in any of the "valid withdraw merkle-roots".
 This will transfer their tokens from the smart contract's into their public address.
 In order to avoid double withdraws, we also store a bitmap for each "withdraw merkle-root".

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -18,7 +18,7 @@ The matching process is decentralized.
 After orders have been collected over a certain amount of time, a batch is frozen and any sufficiently bonded participant can suggest a matching of orders in the current batch.
 
 If more than one solution is submitted within a certain amount of time after the batch closes, the one that generates the largest "trader surplus" (detailed explanation below, for now think "trading volume") is selected and executed.
-For this, the party that suggested the selected solution has to post enough information about the solution on-chain, so that any participant can quickly check the validity of the solution.
+For this, the party whose solution proposal was selected must post sufficient information on-chain, so that other participants can quickly validate.
 
 Anyone can challenge a solution on-chain (while providing a bond and an alternative solution) within a certain time-period after posting.
 Such disputes are resolved by verifying a zkSnark proof on-chain that checks if the provided solution fulfills a number of constraints (specified in detail below).

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -52,7 +52,7 @@ Assuming an order can be encoded in 256 bits, storing a batch of 10.000 on chain
 Instead the smart contract emits a smart contract event containing the relevant order information (account, from_token, to_token, limit) and stores a rolling SHA hash.
 For a new order, the rolling hash is computed by hashing the previous rolling hash with the current order.
 
-Any participants can apply pending deposit and withdrawl requests to the current account balance state.
+Any participants can apply pending deposit and withdrawal requests to the current account balance state.
 To do so, they provide a new state commitment that represents all account balances after the application of pending requests.
 Moreover, as the new state is stored on the smart contract, pending requests are reset.
 

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -45,7 +45,7 @@ Accounts will pay "rent" to occupy an active account. The account index can be u
 Furthermore, we store a bi-map of token address to its index `0 <= t <= T`, for each token that can be traded on the exchange.
 When specifying tokens inside orders, deposits and withdrawel requests, we use the token's index `0 <= t <= T` instead of the full address.
 
-As limit orders, deposits and withdrawl requests are collected they are not directly stored in the smart contract.
+As limit orders and deposits requests are collected they are not directly stored in the smart contract.
 Doing so would require a `SSTORE` evm instruction for each item.
 This would be too gas-expensive:
 Assuming an order can be encoded in 256 bits, storing a batch of 10.000 on chain would cost ~5M gas (5.000 gas for SSTORE * 10.000 orders).

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -33,7 +33,7 @@ We therefore "optimistically" accept solutions and set a crypto-economic incenti
 
 For each account, we chain each of ERC20 token balance together and store them as pedersen hash (not merkleized) in the anchor smart contract.
 This "compressed" representation of all account balances is collision resistant and can thus be used to uniquely commit to the complete "uncompressed" state containing all balances explicitly. 
-The "uncompressed" state will be stored off-chain. All changes to the state will be announced via smart contract events. 
+The "uncompressed" state will be stored off-chain and all state transitions will be announced via smart contract events. 
 Thus, the full state will be fully reproducible for any participant by replaying all blocks since the creation of the smart contract. 
 The following diagram shows how the "compressed" state hash is constructed:
 

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -62,7 +62,7 @@ This will transfer their tokens from the smart contract's into their public addr
 In order to avoid double withdraws, we also store a bitmap for each "withdraw merkle-root".
 Each bit in that maps denotes if the withdraw has alreay been claimed.
 
-Participants can provide state transitions that apply pending deposits and withdrawls only while the order collection process is ongoing (the current batch is not yet frozen).
+Participants can provide state transitions that apply pending deposits and withdrawals only while the order collection process is ongoing (the current batch is not yet frozen).
 Since price finding and order matching is a computationally expensive task, we don't want the account state to change while the optimization problem is ongoing, as this could potentially invalidate correct solutions (e.g. a withdraw could lead to insufficient balance for a matched trade).
 As soon as the matching of a closed batch is applied, pending withdrawls and deposits can again be applied to the state.
 

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -80,8 +80,7 @@ To summarize, here is a list of state that is stored inside the smart contract:
 
 The trading workflow consists of the following sequential processes:
 1. On-Chain order collection
-2. Finding the batch price: 
-tion of batch trading surplus (off-chain)
+2. Finding the batch price: optimization of batch trading surplus (off-chain)
 3. Verifying batch price and trade execution (zkSnark)
 4. Restart with step 1
 
@@ -128,7 +127,7 @@ To process a batch, participants compute the uniform clearing price maximizing t
 The traders surplus of an order is defined as the difference between the uniform clearning price and the limit price, multipied by the volume of the order with respect to some reference token. 
 The exact procedure is described [here]( https://github.com/gnosis/dex-research/blob/master/BatchAuctionOptimization/batchauctions.pdf). 
 Calculating the uniform clearing prices is an np-hard optimization problem and most likely the global optimum will not be found in the pre-defined short time frame: `SolvingTime` - estimated between 3-10 minutes. 
-While it is a pity that the global optimum cannot be found, the procedure is still fair, as everyone can submit their best solution.
+While we are unlikely to find a global optimum, the procedure is still fair, as everyone can submit their best solution.
 Since posting the complete solution (all prices and traded volumes) would be too gas expensive to put on-chain for each candidate solution, participants only submit the 'traders surplus' they claim there solution is able to achieve.
 The anchor contract will store all submissions and will select the solution with the maximal 'traders surplus' as the final solution.
 

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -18,20 +18,23 @@ The matching process is decentralized.
 After orders have been collected over a certain amount of time, a batch is frozen and any sufficiently bonded participant can suggest a matching of orders in the current batch.
 
 If more than one solution is submitted within a certain amount of time after the batch closes, the one that generates the largest "trader surplus" (detailed explanation below, for now think "trading volume") is selected and executed.
-For this, the "winner" has to post enough information about the solution on-chain, so that any participant can quickly check the validity of the solution.
+For this, the party that suggested the selected solution has to post enough information about the solution on-chain, so that any participant can quickly check the validity of the solution.
 
 Anyone can challenge a solution on-chain (while providing a bond and an alternative solution) within a certain time-period after posting.
 Such disputes are resolved by verifying a zkSnark proof on-chain that checks if the provided solution fulfills a number of constraints (specified in detail below).
 If the verification succeeds, the challenger loses their bond and the state is "finalized". 
-If the verification fails the provided alternative state is assumed correct unless challenged within a certain time.
+If the verification fails the original proposer loses their bond and the provided alternative state is assumed correct unless also challenged within a certain time.
+In case no-one submits a proof, the verification automatically fails after a certain amount of time.
+
+The reason for having such a bonded challenge-response interaction is that generating zkSnark proofs is very time consuming (much longer than the turnaround time we envision for each batch).
+We therefore "optimistically" accept solutions and set a crypto-economic incentive to only post valid solutions.
 
 ## State stored in the smart contract
 
 For each account, we chain each of ERC20 token balance together and store them as pedersen hash (not merkleized) in the anchor smart contract.
-This "compressed" representation of all account balances is collision resistant and can thus be used to uniquely commit to the complete "uncompressed" state that lists all balances explicitly.
-The "uncompressed" state will be stored off-chain.
-All changes to the state will be announced via smart contract events.
-Thus, the full state will be fully reproducible for any participant by replaying all blocks since the creation of the smart contract.
+This "compressed" representation of all account balances is collision resistant and can thus be used to uniquely commit to the complete "uncompressed" state that lists all balances explicitly. 
+The "uncompressed" state will be stored off-chain. All changes to the state will be announced via smart contract events. 
+Thus, the full state will be fully reproducible for any participant by replaying all blocks since the creation of the smart contract. 
 The following diagram shows how the "compressed" state hash is constructed:
 
 ![State construction](./dFusion%20rootHash.png?raw=true "State construction")
@@ -42,28 +45,45 @@ Accounts will pay "rent" to occupy an active account. The account index can be u
 Furthermore, we store a bi-map of token address to its index `0 <= t <= T`, for each token that can be traded on the exchange.
 When specifying tokens inside orders, deposits and withdrawel requests, we use the token's index `0 <= t <= T` instead of the full address.
 
-As orders, deposits and withdrawl requests are collected they are not directly stored in the smart contract.
-Doing so would require a `SSTORE` instruction which would be too gas-expensive.
+As limit orders, deposits and withdrawl requests are collected they are not directly stored in the smart contract.
+Doing so would require a `SSTORE` evm instruction for each item.
+This would be too gas-expensive:
 Assuming an order can be encoded in 256 bits, storing a batch of 10.000 on chain would cost ~5M gas (5.000 gas for SSTORE * 10.000 orders).
 Instead the smart contract emits a smart contract event containing the relevant order information (account, from_token, to_token, limit) and stores a rolling SHA hash.
 For a new order, the rolling hash is computed by hashing the previous rolling hash with the current order.
 
-// TODO: Pending withdrawels
+Any participants can apply pending deposit and withdrawl requests to the current account balance state.
+To do so, they provide a new state commitment that represents all account balances after the application of pending requests.
+Moreover, as the new state is stored on the smart contract, pending requests are reset.
+
+When a party applies withdrawl requests to the account balance state, they also provide the list of valid withdraws (in form of their merkle root) which we store in the smart contract inside a mapping (`transitionId` -> `valid withdraw merkle root`).
+Participants can later claim their withdraw by providing a merkle inclusion proof of their withdraw in any of the "valid withdraw merkle-roots".
+This will transfer their tokens from the smart contract's into their public address.
+In order to avoid double withdraws, we also store a bitmap for each "withdraw merkle-root".
+Each bit in that maps denotes if the withdraw has alreay been claimed.
+
+Participants can provide state transitions that apply pending deposits and withdrawls only while the order collection process is ongoing (the current batch is not yet frozen).
+Since price finding and order matching is a computationally expensive task, we don't want the account state to change while the optimization problem is ongoing, as this could potentially invalidate correct solutions (e.g. a withdraw could lead to insufficient balance for a matched trade).
+As soon as the matching of a closed batch is applied, pending withdrawls and deposits can again be applied to the state.
+
+*// TODO state for snark challenge/response, e.g. hashBatchInfo*
+
+To summarize, here is a list of state that is stored inside the smart contract:
+- Hash of all token balances for each account chained together (Pedersen)
+- Bi-Map of accounts public keys (ethereum addresses) to dƒusion accountId
+- Bi-Map of ERC20 token addresses to internal dƒusion tokenId that the exchange supports
+- Rolling hash of pending orders, withdrawls and deposit requests (SHA)
+- Map of stateTransitionId to pair of "valid withdrawel requests merkle-root" (SHA) and bitmap of already claimed withdraws
+- Current state of the batch auction (e.g. *price-findeing* vs. *order-collection*)
 
 ## Batch Auction Workflow
 
 The trading workflow consists of the following sequential processes:
-0. Account opening, deposits & withdrawels
 1. On-Chain order collection
-2. Transition function from sha to Pedersen hashes (zkSnark)
-3. Finding the batch price: optimization of batch trading surplus (offchain)
-4. Verifying batch price and trade execution (zkSnark)
-5. Processing of pending exits and deposits (zkSnark)
-6. Restart with step 0
-
-### Account opening, deposits & withdrawels
-
-// TODO
+2. Finding the batch price: 
+tion of batch trading surplus (off-chain)
+3. Verifying batch price and trade execution (zkSnark)
+4. Restart with step 1
 
 ### On-Chain order collection
 
@@ -81,122 +101,136 @@ function appendOrders( bytes32 [] orders){
 	for(i=0; i<orders.length; i++){
 		if("check signature and batchID of order") {
 			// hash order without signature
-			orderHashSha = Kecca256(orderHashSha, orders[i]) 
+			byte32 oldHashSha = orderHashSha
+			orderHashSha = Kecca256(oldHashSha, orders[i]) 
+			emit OrderSubmitted(oldHashSha, orders[i], orderHashSha)
 		}
 	}
 }
 ```
-This function will simply update an orderHashSha variable, which is chaining all orders with a valid signature. This function is callable by any party. However, it is expected that “decentralized operators” accept orders from users, bundle them and then include them all together into the function. 
 
-Notice, that the orders are only sent over as transaction payload, but will not be “stored” in the EVM.
+This function will update the rolling hash of pending orders, chaining all orders with a valid signature. 
+This function is callable by any party. 
+However, it is possible that “decentralized operators” accept orders from users, bundle them and then submit them all together in one function call. 
 
-Also notice, that we allow orders, which might not be covered by any balance of the order sender. These orders will be sorted out later in the settlement of an auction.
+Notice, that the orders are only sent over as transaction payload, but will not be “stored” in the EVM (to save gas).
+All relevant information is emitted as events.
+This will allow any participant to reproduce all orders of the current batch by replaying the ethereum blocks since batch creation and filtering them for these events.
 
-### Transition function from sha to Pedersen hashes (zkSnark)
+Also notice, that we allow orders, which might not be covered by any balance of the order sender. 
+These orders will be sorted out later in the settlement of an auction.
 
-In the first step, the orders are hashed together using SHA256 since this is very cheap on the EVM. However, SHA256 is very “expensive” in snarks. We therefore translate the resulting orderHash into a pedersen hash after order collection for a batch has finished. 
+### Finding the batch price: optimization of batch trading surplus (off-chain)
 
-We will use a snark to do this job:
-```
-Snark - TransitionHashes&Validation ( public input: orderHashSha,
-					Private input: [orders])
-					Output: orderHashPedersen
-```
-The transitionHashes&Validation snark will do the following checks:
-- Verify the private input by recalculating SHA256 of all orders and comparing it to the public input `orderHashSha`.
-- Iterate over all orders again and hash them sequencially using the Pedersen hash. Use this hash as output.
-
-Since computing the actual snark proof is very time-intense we optimistically accept state transitions that provide a significant bond instead of the actual proof.
-
-Anyone can propose a transition to the anchor contract by providing the required information:
-
-```js
-Function submitTransitionInformation(uint branchId, bytes32 orderHashPedersen)
-```
-
-In case the information is incorrect, anyone can challenge it by also providing a significant bond and calling the following function.
-
-```js
-Function challengeTransitionInformation(bytes32 orderHashPedersen)
-```
-Any significantly bonded challenge is, by default, assumed to be legitimate and will be executed after a certain time frame (some hours), unless the first transition submitter can provide a snark proof of correctness within this predefined time frame.
-
-The snark will be evaluated by the anchor contract after calling the following function. The contract will populate public inputs and outputs to the snark with the data from the challenged submission.
- ```js
-Function submitSnarkToResolveChallenge(branchId, --snark--)
-```
-
-During the challenge period, multiple "forks" of the state will be stored (one for each submitted solution). . While producing a snark proof takes a lot of time, executing the computation in a native program on a local computer is fast. Therefore any client should be able to "predict", which challenges will be successful and can thus chose on which fork they want to continue trading.
-
-### Finding the batch price: optimization of batch trading surplus (offchain)
-
-After the previous step, the orders participating in a batch have finalized. Now, the uniform clearing price maximizing the trading surplus between all trading pairs can be calculated. The traders surplus of one order is the difference between the uniform clearning price and the limit price, multipied by the volume of the order with respect to some reference token. The exact procedure is described [here]( https://github.com/gnosis/dex-research/blob/master/BatchAuctionOptimization/batchauctions.pdf). Calculating the uniform clearing prices is an np hard optimization problem and most likely the global optimum will not be found in the pre-defined short time frame: `SolvingTime` - we think that 3-10 minutes are reasonable. While it is a pity that the global optimum cannot be found, the procedure is still fair, as everyone can submit their best solution. The anchor contract will store all submissions and will select the solution with the maximal 'traders surplus' as the final solution. We define the traders surplus as the sum of all differences between the uniform clearning prices and the limit price of an touched order multiplied by the surplus of the order.
+After a certain time-frame or once the maximum number of orders per batch are collected, a batch is "frozen" and the orders participating in it are final.
+A new batch could immediately start collecting new orders while the previous one is being processed.
+To process a batch, participants compute the uniform clearing price maximizing the trading surplus between all trading pairs can. 
+The traders surplus of an order is defined as the difference between the uniform clearning price and the limit price, multipied by the volume of the order with respect to some reference token. 
+The exact procedure is described [here]( https://github.com/gnosis/dex-research/blob/master/BatchAuctionOptimization/batchauctions.pdf). 
+Calculating the uniform clearing prices is an np hard optimization problem and most likely the global optimum will not be found in the pre-defined short time frame: `SolvingTime` - we think that 3-10 minutes are reasonable. 
+While it is a pity that the global optimum cannot be found, the procedure is still fair, as everyone can submit their best solution.
+Since posting the complete solution (all prices and traded volumes) would be too gas expensive to put on-chain for each candidate solution, participants only submit the 'traders surplus' they claim there solution is able to achieve.
+The anchor contract will store all submissions and will select the solution with the maximal 'traders surplus' as the final solution.
 
 This means the uniform clearing price of the auction is calculated in a permission-less decentralized way.	
-Each time a solution is submitted to the anchor contract, of course, the submitter also needs to bond himself. If he provides the solution, he also has to provide in the next process step the balance update information and has to answer any challenge request.
-
+Each time a solution is submitted to the anchor contract, the submitter also needs to bond themselves so that they can be penalized if their solutions later turns out incorrect.
+The participant providing the winning solution will later also have to provide the updated account balances that result from applying their order matching.
+In return for their efforts, solution providers will be rewarded with a fraction of transaction fees that are collected for each order.
 
 ### Verifying batch price and trade execution (zkSnark)
 
-
-After the price submission period, the best solution with the highest trading surplus will be chosen by the anchor contract. The submitter of this solution needs to do 2 steps:
-
-1) posting the full solution into the ethereum chain as payload. The solution is a price vector P, a new stateHash with the updated account balances, a vector of trading surpluss (VV) for each order.
+After the solution submission period, the best solution with the highest trading surplus will be chosen by the anchor contract. 
+The submitter of this solution then needs to post the full solution into the ethereum chain as calldata payload. 
+The solution is a new stateHash with the updated account balances, a price vector `P`:
 
 | P | Token_1:Token_1 | ... | Token_T:Token_1|
 | --- | --- | --- | --- | 
 | price | p_1 | ... | p_T |
 
 
-`P` is only the price vector of all prices relative to a reference token `Token_1`. As prices are arbitrage-free, we can calculate the `price Token_i: Token_k` =  `(Token_i:Token_1):(Token_1:Token_k)`
+of all prices relative to a reference token `Token_1`. Since prices are arbitrage-free, we can calculate the `price Token_i: Token_k` =  `(Token_i:Token_1):(Token_1:Token_k)`.
 
-Unfortunately, not all orders below the limit price will be filled completely. It might happen that the account sending the order might not have the balance required to settle the sell order. We are calling these "uncovered orders" and they need to be excluded or only partly be filled. Because of this, the solution submitter must provide the fraction of the traded surplus for each order:
+Along with the prices, the solution submitter also has to post a vector `V` of `buyVolumes` for each order:
 
-| VV | order_1 | ... | order_K|
+| V | order_1 | ... | order_K|
 | --- | --- | --- | --- |
-| fraction | o_1 | --- | o_K |
+| buyVolume | o_1 | --- | o_K |
 
+Anyone can caluclate the `sellVolume` from the price of the token pair and the buyVolume.
 
+The solution submitter also submits a pedersen hash of all orders that were inside the applied batch.
+This pedersen hash is assumed to be equivalent to the sha hash of all orders that is already stored in the smart contract (the equivalence can be challenged).
+The reason we prefer having the hash as a pedersen hash is that it can be calculated much more efficiently inside a snark.
+The size of our batch is bound by the amount of orders that the `applyAuction` snark (see below) can compute.
+By spending less computation on hashing we can fit process larger batches inside `applyAuction`.
 
-These two parts of the solution: VV and P are provided as data payload to the anchor contract which will sha-hash them together into `hashBatchInfo`.
+*//TODO what if the participant that claimed the surplus never submits? Are we sequentially degrading to second best, third best solution, or at that point allowing any solution?*
 
-Now, everyone can check whether the provided solution is actually a valid one. If it is not valid, then anyone can challenge the solution submitter. If this happens, the solution submitter needs to prove that his solution is correct by providing the following snark:
+The new state is optimistically assumed correct and the pedersen hash equivalent of orderHash is stored alongside as trasition metadata. 
+V and P are provided as data payload to the anchor contract which will hash them together into `hashBatchInfo` (which is also stored as transition metadata).
+With this hash the solution is unambiguously "committed" on-chain with a minimum amount of gas.
+If someone challenges the solution later, the smart contract can verify that a proof is for this particular solution by requiring that the private inputs to the proof hash to the values stored metadata.
+
+The full uncompressed solution is also emitted as a smart contract event so that everyone can check whether the provided solution is actually a valid one. 
+If it is not valid, then anyone can challenge the solution submitter (again providing a bond and an alternative solution).
+
+*// TODO: I could "win" the price-finding by committing to an absurdly large surplus, then submit a wrong solution, challenge myself with a correct solution that is much worse than the second surplus best.*
+
+There are two types of challenges:
+1.) Challenging that the pedersen hash of all orders doesn't match the sha hash already stored in the smart contract
+2.) Challenging that the matching logic is incorrect (e.g. not arbitrage free, not respecting limit prices of an orders, or adjusting balance incorrectly)
+
+To resolve a challenge of type 1), the solution submitter needs to prove that his solution is correct by providing proof for the following zkSnark:
+
 ```
-Snark - applyAuction(
+zkSnark - TransitionHashes&Validation ( public input: orderHashSha,
+					public input: orderHashPedersen,
+					Private input: [orders])
+```
+
+It will do the following checks:
+
+- `orders` hashes to `input.orderHashSha`
+- `orders` hashes to `input.orderHashPedersen`
+
+To resolve a challenge of type 2), the solution submitter needs to prove that his solution is correct by providing proof for the following zkSnark:
+
+```
+zkSnark - applyAuction(
 	Public: state,
-	Public: tradingWelfare,
+	Public: tradingSurplus,
 	Public: hashBatchInfo,
-	Public: orderHashPedersen,
-	Private: priceMatrix PxP,
-	Private: volumeVector
-	Private: balances
+	Public: orderHash,
+	Private: priceVector,
+	Private: volumeVector,
+	Private: balances,
 	Private: orders,
 	Output: newstate
 )
 ```
-The snark would check the following things:
+The snark verifies the following:
 
-- `priceMatrix` has actually the values as induced by the `hashBatchInfo` (with sha)
-- `orderVolume` VV has actually the values induced by the `hashBatchInfo` (with sha)
-- verify `[tok_j_i for 0<j<K & 0<i<=T]` hashes to `state` (with pedersen)
+- `priceVector` and `buyVolumes` hashes to `input.hashBatchInfo` (with sha)
+- `balances` hashes to `input.state` (with pedersen)
+- `orders` hashes to `input.orderHash` (with pedersen)
 
-- let `currentOrderHash = 0`
-- for order in [orders]
-	- read the potentially fractional surplus of the order
-	- update the balance by subtracting sell volume
-	- update the balance by adding buy volume
-	- Keep track of the total `selling surplus` per token
-	- Keep track of the total `buying surplus` per token
-	- Keep track of the total `selling volume` per token
-	- Keep track of the total `buying volume ` per token
-	- update `currentOrderHash = hash(currentOrderHash, order)` (with pedersen)
+- for each `order` in `orders`
+	- `order.buyVolume` and `order.sellVolume` have same ratio as `order.buyToken` and `order.sellToken`
+	- Verify tnhe order only has non-zero volume if the limit price is below the market price
+	- Verify the order has not more volume than specified in `order.amount`
+	- Calculate trader surplus for this order
+	- Increment total surplus according to surplus of order
+	- Increment `totalSellVolume[order.sellToken]` by `order.sellAmount`
+	- Increment `totalBuyVolume[order.BuyToken]` by `order.buyAmount`
+	- Update the balance of the order author by subtracting `order.sellVolume` from `balance[order.sellToken]`
+	- Update the balance of the order author by addint `order.buyVolume` from `balance[order.buyToken]`
 	
-- For all token, check that `selling volume == buying volume`
-- Check that `selling surplus + buying surplus == tradingWelfare`
-- Check that `currentOrderHash == orderHashPedersen`
-- For all balances, check that `balance > 0` and calculate/return `newstate`
+- For all tokens `t`, check that `totalSellVolume[t] == totalBuyVolume[t]` (solution doesn't mint or burn tokens)
+- Check that `tradingSurplus == input.tradingSurplus`
+- For all balances, check that `balance > 0` 
+- return `newstate` by hashing all balances together (with pedersen)
 
-### Processing of pending exits and deposits (zkSnark)
+## Processing of pending exits and deposits (zkSnark)
 
 Deposits and withdraws need to be processed and incorporated into the 'stateHash' as well. For this, we make again use of snarks and specific challenging periods.
 

--- a/dFusion/dFusionSpec.md
+++ b/dFusion/dFusionSpec.md
@@ -46,7 +46,7 @@ Furthermore, we store a bi-map of token address to its index `0 <= t <= T`, for 
 When specifying tokens inside orders, deposits and withdrawel requests, we use the token's index `0 <= t <= T` instead of the full address.
 
 As limit orders and deposits and withdrawal requests are collected they are not directly stored in the smart contract.
-Doing so would require a `SSTORE` evm instruction for each item.
+Doing so would require a `SSTORE` EVM instruction for each item.
 This would be too gas-expensive:
 Assuming an order can be encoded in 256 bits, storing a batch of 10.000 on chain would cost ~5M gas (5.000 gas for SSTORE * 10.000 orders).
 Instead the smart contract emits a smart contract event containing the relevant order information (account, from_token, to_token, limit) and stores a rolling SHA hash.


### PR DESCRIPTION
- Adding more information on the state that needs to be stored in the smart contract.
- Combining sha->pedersen transition and order execution to a single submission that can be challenged in two parts (@josojo this is a change, that I think will make the overall state machine/interaction with the simpler).

Still missing information on opening/closing accounts, registering tokens, deposits, withdrawls.

@bh2smith please feel free to commandeer, change further and eventually merge.